### PR TITLE
declare variable t in Chap3/cad1.js

### DIFF
--- a/Chap3/cad1.js
+++ b/Chap3/cad1.js
@@ -8,7 +8,7 @@ var maxNumVertices  = 3 * maxNumTriangles;
 var index = 0;
 var first = true;
 
-var t1, t2, t3, t4;
+var t, t1, t2, t3, t4;
 
 var cIndex = 0;
 


### PR DESCRIPTION
`Chap3/cad1` is not working in Firefox because it doesn't like undeclared variables with `"use strict"`.
