### PR TITLE
fix canvas tag syntax errors

### DIFF
--- a/Chap10/mandelbrot1.html
+++ b/Chap10/mandelbrot1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <script id="vertex-shader" type="x-shader/x-vertex">
@@ -33,7 +34,7 @@ void main()
 <script type="text/javascript" src="mandelbrot1.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="1024"" height="1024"
+<canvas id="gl-canvas" width="1024" height="1024">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 </body>

--- a/Chap10/mandelbrot2.html
+++ b/Chap10/mandelbrot2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <div>
  Center X -2  <input id="Center X" type="range"
@@ -88,7 +89,7 @@ void main()
 <script type="text/javascript" src="mandelbrot2.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="1000" height="1000"
+<canvas id="gl-canvas" width="1000" height="1000">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 </body>

--- a/Chap3/cad1.html
+++ b/Chap3/cad1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <script id="vertex-shader" type="x-shader/x-vertex">
@@ -31,7 +32,7 @@ void main()
 
 <body>
 <div>
-<canvas id="gl-canvas" width="512"" height="512"
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 </div>

--- a/Chap3/cad2.html
+++ b/Chap3/cad2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <script id="vertex-shader" type="x-shader/x-vertex">
@@ -34,7 +35,7 @@ main()
 
 <body>
 <div>
-<canvas id="gl-canvas" width="512"" height="512"
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 </div>

--- a/Chap3/square.html
+++ b/Chap3/square.html
@@ -37,7 +37,7 @@ main()
 <script type="text/javascript" src="square.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="512" height="512">>
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 </body>

--- a/Chap3/squarem.html
+++ b/Chap3/squarem.html
@@ -37,7 +37,7 @@ main()
 <script type="text/javascript" src="squarem.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="512" height="512">>
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 </body>

--- a/Chap3/triangle.html
+++ b/Chap3/triangle.html
@@ -35,7 +35,7 @@ main()
 <script type="text/javascript" src="triangle.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="512" height="512">>
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 </body>

--- a/Chap4/cube.html
+++ b/Chap4/cube.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <script id="vertex-shader" type="x-shader/x-vertex">
@@ -57,7 +58,7 @@ main()
 <script type="text/javascript" src="cube.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="512"" height="512">
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
    

--- a/Chap4/cubeq.html
+++ b/Chap4/cubeq.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <script id="vertex-shader" type="x-shader/x-vertex">
@@ -62,7 +63,7 @@ main()
 <script type="text/javascript" src="cubeq.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="512"" height="512">
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 

--- a/Chap4/cubev.html
+++ b/Chap4/cubev.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <script id="vertex-shader" type="x-shader/x-vertex">
@@ -57,7 +58,7 @@ main()
 <script type="text/javascript" src="cubev.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="512"" height="512">
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
    

--- a/Chap4/trackball.html
+++ b/Chap4/trackball.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <script id="vertex-shader" type="x-shader/x-vertex">
@@ -39,7 +40,7 @@ main()
 <script type="text/javascript" src="trackball.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="512"" height="512">
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 

--- a/Chap4/trackballQuaterion.html
+++ b/Chap4/trackballQuaterion.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <script id="vertex-shader" type="x-shader/x-vertex">
@@ -60,7 +61,7 @@ main()
 <script type="text/javascript" src="trackballQuaterion.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="512"" height="512">
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 

--- a/Chap7/cubet.html
+++ b/Chap7/cubet.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 
@@ -58,7 +59,7 @@ main()
 <script type="text/javascript" src="cubet.js"></script>
 
 <body>
-<canvas id="gl-canvas" width="512"" height="512">
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
    

--- a/Chap9/figure.html
+++ b/Chap9/figure.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 
@@ -104,7 +105,7 @@ right lower leg angle -180 <input id="slide" type="range"
 
 
 <body>
-<canvas id="gl-canvas" width="512"" height="512"
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 </body>

--- a/Chap9/robotArm.html
+++ b/Chap9/robotArm.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <script id="vertex-shader" type="x-shader/x-vertex">
@@ -55,7 +56,7 @@ upper arm angle -180 <input id="slide" type="range"
 
 
 <body>
-<canvas id="gl-canvas" width="512"" height="512"
+<canvas id="gl-canvas" width="512" height="512">
 Oops ... your browser doesn't support the HTML5 canvas element
 </canvas>
 </body>


### PR DESCRIPTION
Sometimes `<canvas>` has no closing angle bracket, sometimes it has two. Sometimes it is invalid just because there's no html5 doctype.
