### PR TITLE
Fixed transpose() to support non-square matrices.

### DIFF
--- a/Common/MV.js
+++ b/Common/MV.js
@@ -277,22 +277,23 @@ function mult( u, v )
     var result = [];
 
     if ( u.matrix && v.matrix ) {
-        if ( u.length != v.length ) {
-            throw "mult(): trying to add matrices of different dimensions";
-        }
-
-        for ( var i = 0; i < u.length; ++i ) {
-            if ( u[i].length != v[i].length ) {
-                throw "mult(): trying to add matrices of different dimensions";
+        var M = u.length;
+        var N = v.length;
+        var P = v[0].length;
+        
+        // Check that inner dimensions match.
+        for ( var i = 0; i < M; ++i ) {
+            if ( u[i].length != N ) {
+                throw "mult(): dimension mismatch";
             }
         }
 
-        for ( var i = 0; i < u.length; ++i ) {
+        for ( var i = 0; i < M; ++i ) {
             result.push( [] );
 
-            for ( var j = 0; j < v.length; ++j ) {
+            for ( var j = 0; j < P; ++j ) {
                 var sum = 0.0;
-                for ( var k = 0; k < u.length; ++k ) {
+                for ( var k = 0; k < N; ++k ) {
                     sum += u[i][k] * v[k][j];
                 }
                 result[i].push( sum );

--- a/Common/MV.js
+++ b/Common/MV.js
@@ -505,11 +505,11 @@ function transpose( m )
     if ( !m.matrix ) {
         return "transpose(): trying to transpose a non-matrix";
     }
-
+    
     var result = [];
-    for ( var i = 0; i < m.length; ++i ) {
+    for ( var i = 0; i < m[0].length; ++i ) {
         result.push( [] );
-        for ( var j = 0; j < m[i].length; ++j ) {
+        for ( var j = 0; j < m.length; ++j ) {
             result[i].push( m[j][i] );
         }
     }


### PR DESCRIPTION
The current implementation of transpose() creates a result whose number of rows is the same as the input's number of rows, and whose number of columns is also the same as the input's.  I imagine this is based on an assumption that matrices are always square.  However, non-square matrices are useful, for example, for representing all the vertices of a shape.  If a non-square matrix is passed in, then the result may have empty rows and missing columns.

My change fixes transpose() to work correctly with non-square matrices.  It still assumes that all rows are the same length, even though it's possible to create a list-of-lists with different lengths for the inner lists.
