### PR TITLE
Support for non-square matrices

### DIFF
--- a/Common/MV.js
+++ b/Common/MV.js
@@ -277,22 +277,23 @@ function mult( u, v )
     var result = [];
 
     if ( u.matrix && v.matrix ) {
-        if ( u.length != v.length ) {
-            throw "mult(): trying to add matrices of different dimensions";
-        }
-
-        for ( var i = 0; i < u.length; ++i ) {
-            if ( u[i].length != v[i].length ) {
-                throw "mult(): trying to add matrices of different dimensions";
+        var M = u.length;
+        var N = v.length;
+        var P = v[0].length;
+        
+        // Check that inner dimensions match.
+        for ( var i = 0; i < M; ++i ) {
+            if ( u[i].length != N ) {
+                throw "mult(): dimension mismatch";
             }
         }
 
-        for ( var i = 0; i < u.length; ++i ) {
+        for ( var i = 0; i < M; ++i ) {
             result.push( [] );
 
-            for ( var j = 0; j < v.length; ++j ) {
+            for ( var j = 0; j < P; ++j ) {
                 var sum = 0.0;
-                for ( var k = 0; k < u.length; ++k ) {
+                for ( var k = 0; k < N; ++k ) {
                     sum += u[i][k] * v[k][j];
                 }
                 result[i].push( sum );

--- a/Common/MV.js
+++ b/Common/MV.js
@@ -505,11 +505,11 @@ function transpose( m )
     if ( !m.matrix ) {
         return "transpose(): trying to transpose a non-matrix";
     }
-
+    
     var result = [];
-    for ( var i = 0; i < m.length; ++i ) {
+    for ( var i = 0; i < m[0].length; ++i ) {
         result.push( [] );
-        for ( var j = 0; j < m[i].length; ++j ) {
+        for ( var j = 0; j < m.length; ++j ) {
             result[i].push( m[j][i] );
         }
     }


### PR DESCRIPTION
Hi @esangel-

When using your MV.js for a course I'm teaching, I found a couple bugs in transpose() and mult() which seem to stem from an assumption that matrices must always be square.  However, non-square matrices are useful, for example, for representing all the vertices of a shape.

The current implementation of transpose() creates a result whose number of rows is the same as the input's number of rows, and whose number of columns is also the same as the input's.

The current implementation of mult(), when called on two matrices, checks to see that their dimensions exactly match; that is, that if u is MxN, then v must also be MxN. Instead, the correct check is to verify that if u is MxN, then v must be NxP, and the result should be an MxP matrix.

My two patches fix these errors, but still assume that all rows are the same length in a matrix input, even though it's possible to create a list-of-lists with different lengths for the inner lists.

The changes should not disrupt the behavior of the existing code; all calls with square matrices work just the same as they did previously.  Please check them over; I hope you find these to be useful contributions.

-Jadrian
